### PR TITLE
mkfs.axfs-legacy: Allow users to provide additional flags

### DIFF
--- a/mkfs.axfs-legacy/Makefile
+++ b/mkfs.axfs-legacy/Makefile
@@ -1,12 +1,12 @@
-INC = -I./
-CFLAGS = -g $(INC) -O0
+INC += -I./
+CFLAGS += -g $(INC) -O0
 
 MKFSOBJS = mkfs.axfs.o
 
 all:   mkfs.axfs
 
 mkfs.axfs: $(MKFSOBJS)
-	$(CC) $(CFLAGS) -o mkfs.axfs $(MKFSOBJS) -lz
+	$(CC) $(CFLAGS) $(LDFLAGS) -o mkfs.axfs $(MKFSOBJS) -lz
 
 clean_mkfs.axfs:
 	rm -rf $(MKFSOBJS) mkfs.axfs


### PR DESCRIPTION
This patch is currently in Buildroot and is applied after the git clone.
I want to pull this patch back into axfs so I can updated Buildroot and remove the need for the patch.